### PR TITLE
PLAT-71: Load AWS credentials from the container role

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
 FROM alpine:3.3
 
 ENV AWSCLI_VERSION "1.10.38"
-ENV PACKAGES "groff less python py-pip curl openssl ca-certificates mysql-client bash findutils"
+ENV PACKAGES "groff less python py-pip curl openssl ca-certificates mysql-client bash findutils jq"
 
 RUN apk add --update $PACKAGES \
     && pip install awscli==$AWSCLI_VERSION \

--- a/assets/sync_to_s3.sh
+++ b/assets/sync_to_s3.sh
@@ -31,4 +31,11 @@ do_sync() {
     	"s3://${S3_BUCKET_NAME}/${S3_BUCKET_PATH}"
 }
 
+load_aws_credentials(){
+    if [ -n "${AWS_CONTAINER_CREDENTIALS_RELATIVE_URI:-}" ]; then
+	eval $(curl -qs 169.254.170.2$AWS_CONTAINER_CREDENTIALS_RELATIVE_URI | jq -r '"export AWS_ACCESS_KEY_ID=\( .AccessKeyId )\nexport AWS_SECRET_ACCESS_KEY=\( .SecretAccessKey )\nexport AWS_SESSION_TOKEN=\( .Token )"')
+    fi
+}
+
+load_aws_credentials
 do_sync


### PR DESCRIPTION
AWS provides to the containers the credentials for the assume role for
the containers in the metadata endpoint, under a path defined by
the environment variable $AWS_CONTAINER_CREDENTIALS_RELATIVE_URI

It seems that awscli does not load this endpoint automatically, so
we added some logic in the sync_to_s3.sh script to load it, and
a corresponding test.

[1] http://docs.aws.amazon.com/AmazonECS/latest/developerguide/task-iam-roles.html