### PR TITLE
PLAT-71: Change RETENTION logic.

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ Usage:
 It will dump the provided database:
  - in the directory ${DUMPS_PATH}.
  - will keep a naming like: ${DATABASE_DB_NAME}-2017-02-03-17-03.
- - will delete any file older than ${RETENTION} days
+ - will keep the ${RETENTION} dumps more recent
 ```
 
 `/usr/local/bin/sync_to_s3.sh`:

--- a/assets/dump_database.sh
+++ b/assets/dump_database.sh
@@ -43,7 +43,17 @@ dump_mysql() {
 }
 
 delete_old_dumps() {
-	find "${DUMPS_PATH}" -mtime "+${RETENTION}" -a -name 'db-dump-*.sql.gz' | xargs -r rm -vf
+	# This line will:
+	# 1. Find for all the dumps and print the timestamp and name (-printf "%T@ %p\n")
+	# 2. Order by tiemstamp, increasing
+	# 3. the only the name (cut)
+	# 4. Drop the last ${RETENTION} lines.
+	# 5. Delete the rest of the files if any.
+	find "${DUMPS_PATH}" \
+	    -name 'db-dump-*.sql.gz' \
+	    -printf "%T@ %p\n" | \
+		sort -n | cut -f 2- -d ' ' | head -n "-${RETENTION}" | \
+		    xargs -r rm -vf
 }
 
 DUMPFILE="${DUMPS_PATH}/db-dump-${DATABASE_DB_NAME}-$(date +%Y-%m-%d-%H-%M-%S).sql.gz"


### PR DESCRIPTION
Instead of keep ${RETENTION} days, we will keep ${RETENTION} number of
dumps. This would allow to predict better the space used by the dumps
in disks, regardless the times or frequency we perform the dumps.