### PR TITLE
Add support to send event to datadog

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -20,4 +20,7 @@ RUN test -x /usr/local/bin/datadog-notify.sh
 ADD ./assets/datadog_event_finished.sh /usr/local/bin/
 RUN test -x /usr/local/bin/datadog_event_finished.sh
 
-CMD [ "sh", "-c", "/usr/local/bin/dump_database.sh && /usr/local/bin/sync_to_s3.sh && /usr/local/bin/datadog_event_finished.sh" ]
+ADD ./assets/default_command.sh /usr/local/bin/
+RUN test -x /usr/local/bin/datadog_event_finished.sh
+
+CMD [ "/usr/local/bin/default_command.sh" ]

--- a/Dockerfile
+++ b/Dockerfile
@@ -14,4 +14,10 @@ RUN test -x /usr/local/bin/dump_database.sh
 ADD ./assets/sync_to_s3.sh /usr/local/bin/
 RUN test -x /usr/local/bin/sync_to_s3.sh
 
-CMD [ "sh", "-c", "/usr/local/bin/dump_database.sh && /usr/local/bin/sync_to_s3.sh" ]
+ADD ./assets/datadog-notify.sh /usr/local/bin/
+RUN test -x /usr/local/bin/datadog-notify.sh
+
+ADD ./assets/datadog_event_finished.sh /usr/local/bin/
+RUN test -x /usr/local/bin/datadog_event_finished.sh
+
+CMD [ "sh", "-c", "/usr/local/bin/dump_database.sh && /usr/local/bin/sync_to_s3.sh && /usr/local/bin/datadog_event_finished.sh" ]

--- a/README.md
+++ b/README.md
@@ -41,3 +41,11 @@ Other optional variables:
 I will copy all the files from /data into the given S3 bucket.
 ```
 
+Datadog integration:
+
+If `$DATADOG_API_KEY` is set, an event will be sent when both script finishes. Variables:
+
+  * `$DATADOG_API_KEY` Datadog API key to use
+  * `$DATADOG_TAGS` tags to send in the event.
+
+Currently we send and unique event `mysql-s3-backup.finished`

--- a/assets/datadog-notify.sh
+++ b/assets/datadog-notify.sh
@@ -1,0 +1,78 @@
+#!/bin/bash
+#
+# Based on the code from https://github.com/dvmtn/datadog-notify by
+# Developer Mountain https://github.com/dvmtn
+#
+
+function usage(){
+  echo "Usage:" >&2
+  echo "$0 title message [error|warning|info|success] [tags...]" >&2
+  echo "  title:   The title of this event            ie. 'Foo Restated'" >&2
+  echo "  message: The message for this event         ie. 'Foo was restarted by monit'" >&2
+  echo "  type:    The event type, one of 'info', 'error', 'warning' or 'success'" >&2
+  echo "  tags:    Optional tags in key:vaule format  ie. 'app:foo group:bar" >&2
+  echo >&2
+  echo "Examples:" >&2
+  echo "$0 'Test Event' 'This event is just for testing' 'test:true foo:bar'" >&2
+  echo "$0 'Another Event' 'This event is just for testing'" >&2
+  exit 1
+}
+
+set -e -u -o pipefail
+
+title="${1:-}"
+message="${2:-}"
+alert_type="${3:-}"
+tags="${4:-}"
+
+dd_config='/etc/dd-agent/datadog.conf'
+
+api_key=""
+
+if [[ -n "$DATADOG_API_KEY" ]]; then
+  api_key="$DATADOG_API_KEY"
+else
+  api_key=$(grep '^api_key:' $dd_config | cut -d' ' -f2)
+fi
+
+if [[ -z "$api_key" ]]; then
+  echo "Could not find Datadog API key in either ${dd_config} or DATADOG_API_KEY environment variable." >&2
+  echo "Please provide your API key in one of these locations" >&2
+  usage
+fi
+
+if [[ -z "$title" || -z "$message" ]]; then
+  usage
+fi
+
+if [[ -z "$alert_type" ]]; then
+  echo "No level set, assuming 'info'" >&2
+  alert_type='info'
+fi
+
+case "$alert_type" in
+  ""|error|warning|info|success)
+  ;;
+  *)
+    echo "Failed: alert_type was '$alert_type', needs to be one of 'success', 'info', 'error' or 'warning'" >&2
+    echo >&2
+    usage
+  ;;
+esac
+
+tags=$(echo "$tags" | sed 's/\s\+/\",\"/g;s/^/\"/;s/$/"/'  )
+
+api="https://app.datadoghq.com/api/v1"
+datadog="${api}/events?api_key=${api_key}"
+
+payload=$(cat <<-EOJ
+  {
+    "title": "$title",
+    "text": "$message",
+    "tags": [$tags],
+    "alert_type": "$alert_type"
+  }
+EOJ
+)
+
+curl -s -X POST -H "Content-type: application/json" -d "$payload" "$datadog"

--- a/assets/datadog_event_finished.sh
+++ b/assets/datadog_event_finished.sh
@@ -1,0 +1,8 @@
+#!/bin/bash
+
+SCRIPT_DIR="$(dirname $0)"
+
+if [ -n "${DATADOG_API_KEY}" ]; then
+  echo "Sending event mysql-s3-backup.finished[${DATADOG_TAGS}] to DataDog"
+  ${SCRIPT_DIR}/datadog-notify.sh mysql-s3-backup.finished "Mysql Dump and Sync to S3 has finished" info "${DATADOG_TAGS:-}"
+fi

--- a/assets/default_command.sh
+++ b/assets/default_command.sh
@@ -1,0 +1,11 @@
+#!/usr/bin/env bash
+
+set -e
+
+SCRIPTS_PATH=${SCRIPTS_PATH:-/usr/local/bin}
+
+trap 'echo "Backup job finished with exit code: $?"'  EXIT INT TERM
+
+"${SCRIPTS_PATH}"/dump_database.sh
+"${SCRIPTS_PATH}"/sync_to_s3.sh
+"${SCRIPTS_PATH}"/datadog_event_finished.sh

--- a/test/all_test.sh
+++ b/test/all_test.sh
@@ -5,3 +5,4 @@ set -e -o pipefail -u
 SCRIPT_DIR="$(dirname $0)"
 "${SCRIPT_DIR}"/dump_database_test.sh
 "${SCRIPT_DIR}"/sync_to_s3_test.sh
+"${SCRIPT_DIR}"/datadog_test.sh

--- a/test/datadog_test.sh
+++ b/test/datadog_test.sh
@@ -1,0 +1,75 @@
+#!/usr/bin/env bash
+
+set -e -u -o pipefail
+
+PROJECT_DIR="$(dirname $0)/.."
+SCRIPT_DIR="$(dirname $0)"
+
+source "${SCRIPT_DIR}/common.sh"
+
+# before all
+export TEMPDIR_ROOT="$(mktemp -d)"
+trap "{ rm -rf ${TEMPDIR_ROOT:-/tmp/dummy}; }" EXIT INT TERM
+
+
+# Mock curl and aws commands
+mkdir "${TEMPDIR_ROOT}/bin"
+cat > "${TEMPDIR_ROOT}/bin/curl" <<"EOF"
+#!/bin/bash
+for i in "$@"; do
+	echo "${i}"
+done
+touch "${TEMPDIR_ROOT}/curl_called"
+EOF
+chmod +x "${TEMPDIR_ROOT}"/bin/*
+export PATH="${TEMPDIR_ROOT}/bin:${PATH}"
+
+_before_each() {
+	true
+}
+
+_after_each() {
+	true
+}
+
+it_does_not_send_event_if_datadog_key_missing() {
+	export DATADOG_API_KEY=
+	"${PROJECT_DIR}/assets/datadog_event_finished.sh" > /dev/null
+ 	if test -f "${TEMPDIR_ROOT}/curl_called"; then
+ 		echo "Error: curl should not be called"
+ 		return 1
+ 	fi
+}
+
+it_does_sends_event_to_datadog() {
+	export DATADOG_API_KEY=__datadog_api_key
+	output=$("${PROJECT_DIR}/assets/datadog_event_finished.sh")
+
+ 	if ! test -f "${TEMPDIR_ROOT}/curl_called"; then
+ 		echo "Error: curl should be called"
+ 		return 1
+ 	fi
+ 	echo "${output}" | grep -q 'https://app.datadoghq.com/api/v1/events?api_key=__datadog_api_key' || return $?
+ 	echo "${output}" | grep -q '"title": "mysql-s3-backup.finished"' || return $?
+ 	echo "${output}" | grep -q '"text": "Mysql Dump and Sync to S3 has finished"' || return $?
+ 	echo "${output}" | grep -q 'Content-type: application/json' || return $?
+}
+
+it_does_send_the_tags() {
+set -e -u -o pipefail
+	export DATADOG_API_KEY=__datadog_api_key
+	export DATADOG_TAGS="tag1:val1 tag2:val2"
+	output=$("${PROJECT_DIR}/assets/datadog_event_finished.sh")
+
+ 	if ! test -f "${TEMPDIR_ROOT}/curl_called"; then
+ 		echo "Error: curl should be called"
+ 		return 1
+ 	fi
+ 	echo "${output}" | grep -q '["tag1:val1","tag2:val2"]' || return $?
+ 	echo "${output}" | grep -q '"title": "mysql-s3-backup.finished"' || return $?
+ 	echo "${output}" | grep -q '"text": "Mysql Dump and Sync to S3 has finished"' || return $?
+}
+
+_run it_does_not_send_event_if_datadog_key_missing
+_run it_does_sends_event_to_datadog
+_run it_does_send_the_tags


### PR DESCRIPTION
Send an event to datadog if $DATADOG_API_KEY and $DATADOG_TAGS are
set. This would allow to create monitors for the backup.