### PR TITLE
Implement optional SYNC_EXCLUDE variable

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,7 +36,8 @@ Usage:
 		sync_to_s3.sh
 
 Other optional variables:
-	S3_ENDPOINT=...
+	S3_ENDPOINT=...  - S3 endpoint to connect to
+	SYNC_EXCLUDE=/data/dir/* - Directory to exclude
 
 I will copy all the files from /data into the given S3 bucket.
 ```

--- a/assets/sync_to_s3.sh
+++ b/assets/sync_to_s3.sh
@@ -12,7 +12,8 @@ Usage:
 		${SCRIPT_NAME}
 
 Other optional variables:
-	S3_ENDPOINT=...
+	S3_ENDPOINT=...  - S3 endpoint to connect to
+	SYNC_EXCLUDE=/data/dir/* - Directory to exclude
 
 I will copy all the files from /data into the given S3 bucket.
 EOF
@@ -27,6 +28,7 @@ do_sync() {
     aws s3 sync \
     	--delete \
     	${S3_ENDPOINT:+--endpoint-url ${S3_ENDPOINT}} \
+	${SYNC_EXCLUDE:+--exclude "${SYNC_EXCLUDE}"} \
     	"${SYNC_ORIGIN_PATH}" \
     	"s3://${S3_BUCKET_NAME}/${S3_BUCKET_PATH}"
 }


### PR DESCRIPTION
You can pass a SYNC_EXCLUDE variable with a path to be excluded during
s3 sync. This is to exclude directories which content is not required to
backup but changes a lot, like, for instance, indexes in jira.

How to test?
-------------

A test has been added. So code review and run the tests with `./test-local.sh`
