### PR TITLE
Ensure dump disables foreign key checks

### DIFF
--- a/assets/dump_database.sh
+++ b/assets/dump_database.sh
@@ -34,7 +34,10 @@ dump_mysql() {
 		"--user=${DATABASE_USERNAME}" \
 		"--password=${DATABASE_PASSWORD}" \
 		--add-drop-database \
-		--compact \
+		--skip-add-drop-table \
+		--skip-add-locks \
+		--skip-disable-keys \
+		--skip-set-charset \
 		--compress \
 		--single-transaction \
 		"${DATABASE_DB_NAME}" | gzip -c - > ${DUMPFILE}


### PR DESCRIPTION
When dumping a DB, if the tables have foreign keys, it can happen that
the dump creates first the dependant table rather than the table with
the key.

To allow import the DB we must pass the command:

    SET FOREIGN_KEY_CHECKS=0;

Otherwise, the import would fail with the error:

    ERROR 1215 (HY000) at line 3: Cannot add foreign key constraint

But using the option --compact during the dump, will remove these
commands [1]. We must replace the --compact with
`--skip-add-drop-table --skip-add-locks --skip-disable-keys --skip-set-charset`

We modify the test to simulate this error and fix the command.

[1] https://stackoverflow.com/a/30059436/395686