### PR TITLE
Remove any duplicated slash in bucket url

### DIFF
--- a/assets/sync_to_s3.sh
+++ b/assets/sync_to_s3.sh
@@ -24,13 +24,23 @@ if [ -z "${SYNC_ORIGIN_PATH}" ] && ! [ -d "${SYNC_ORIGIN_PATH}" ]; then
     exit 1
 fi
 
+remove_double_slashes() {
+    local a="$1"
+    local b=""
+    while [ "$b" != "$a" ]; do
+	b="$a"; a="${b//\/\//\/}";
+    done;
+    echo "$a"
+}
+
 do_sync() {
+    target_path=s3://$(remove_double_slashes "${S3_BUCKET_NAME}/${S3_BUCKET_PATH}")
     aws s3 sync \
     	--delete \
     	${S3_ENDPOINT:+--endpoint-url ${S3_ENDPOINT}} \
 	${SYNC_EXCLUDE:+--exclude "${SYNC_EXCLUDE}"} \
     	"${SYNC_ORIGIN_PATH}" \
-    	"s3://${S3_BUCKET_NAME}/${S3_BUCKET_PATH}"
+	"${target_path}"
 }
 
 load_aws_credentials(){


### PR DESCRIPTION
What?
-----

If you have duplicated slash `/` in your S3 url when syncing to it,
S3 cli will happily create those objects with the double slash.

In S3 it does not really exist the concept of folders, each object has a
key that is the full path.

Having multiple slashes in the key  causes troubles.
In the console it appears as a folder without name,
and in aws cli the output is confusing and it might look like the
directory is empty. This can be confusing for the operator.

To avoid that, we sanitise the directory before uploading.

How to review?
------------

Code review. A test has been provided.

How to apply the change?
-------------------------------

Our current backups have this problem, and they have a double trailing slash. Providing that to fix that we need to actually copy all the files again and delete the old, it is better to simply merge this and let the back upload the files. Later cleanup the old backups.